### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We use
 to compile the cards from markdown to actual anki decks:
 
 ```shell
-mdanki input output
+mdankideck input output
 ```
 
 This will create the cards in the output folder.


### PR DESCRIPTION
Corrected the install command. When i install markdown-anki-deck with the provided link, the actual command is `mdankideck` and not `mdanki`